### PR TITLE
Support JSON payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![PyPI - Version](https://img.shields.io/pypi/v/scarf-sdk)
 <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=337d6c89-63ff-4430-865b-2b0dd211eb0c" />
 
-A Python client for sending telemetry events to Scarf.
+A Python client for sending telemetry events to Scarf using JSON payloads.
 
 ## Installation
 
@@ -26,7 +26,10 @@ logger = ScarfEventLogger(
 success = logger.log_event({
     "event": "package_download",
     "package": "scarf",
-    "version": "1.0.0"
+    "details": {
+        "version": "1.0.0",
+        "platforms": ["linux", "macos"]
+    }
 })
 
 # Send an event with a custom timeout
@@ -50,6 +53,7 @@ The client can be configured through environment variables:
 ## Features
 
 - Simple API for sending telemetry events
+- JSON payloads (supports nested data)
 - Environment variable configuration
 - Configurable timeouts (default: 3 seconds)
 - Respects user Do Not Track settings

--- a/scarf/event_logger.py
+++ b/scarf/event_logger.py
@@ -10,7 +10,6 @@ from .version import __version__
 class ScarfEventLogger:
     """A client for sending telemetry events to Scarf."""
 
-    SIMPLE_TYPES = (str, int, float, bool, type(None))
     DEFAULT_TIMEOUT = 3.0  # 3 seconds
 
     def __init__(
@@ -90,23 +89,6 @@ class ScarfEventLogger:
             scarf_no_analytics in ('1', 'true')
         )
 
-    def _validate_properties(self, properties: Dict[str, Any]) -> None:
-        """Validate that all property values are simple types.
-
-        Args:
-            properties: Dictionary of properties to validate
-
-        Raises:
-            ValueError: If any property value is not a simple type
-        """
-        for key, value in properties.items():
-            if not isinstance(value, self.SIMPLE_TYPES):
-                type_names = ', '.join(t.__name__ for t in self.SIMPLE_TYPES)
-                raise ValueError(
-                    f"Property '{key}' has invalid type {type(value)}. "
-                    f"Only simple types are allowed: {type_names}"
-                )
-
     def log_event(
         self,
         properties: Dict[str, Any],
@@ -115,9 +97,9 @@ class ScarfEventLogger:
         """Log a telemetry event to Scarf.
 
         Args:
-            properties: Properties to include with the event.
-                All values must be simple types (str, int, float, bool, None).
-                Example: {'event': 'download', 'package': 'scarf', 'version': '1.0.0'}
+            properties: JSON-serializable properties to include with the event.
+                Nested structures are allowed.
+                Example: {'event': 'download', 'package': 'scarf', 'details': {'version': '1.0.0'}}
             timeout: Optional timeout in seconds for this specific API call.
                 Overrides the default timeout set in the constructor.
 
@@ -125,16 +107,12 @@ class ScarfEventLogger:
             True if the event was sent successfully, False if analytics are disabled
 
         Raises:
-            ValueError: If any property value is not a simple type
             requests.exceptions.RequestException: If the request fails or times out
         """
         if self._check_do_not_track():
             if self.verbose:
                 print("Analytics are disabled via environment variables")
             return False
-
-        if properties:
-            self._validate_properties(properties)
 
         if self.verbose:
             print("\nSending event:")
@@ -145,7 +123,7 @@ class ScarfEventLogger:
         try:
             response = self.session.post(
                 self.endpoint_url,
-                params=properties,
+                json=properties,
                 timeout=timeout if timeout is not None else self.timeout
             )
             response.raise_for_status()

--- a/uv.lock
+++ b/uv.lock
@@ -97,7 +97,7 @@ wheels = [
 
 [[package]]
 name = "scarf-sdk"
-version = "0.1.2"
+version = "0.1.3"
 source = { virtual = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
Scarf now supports JSON payloads, which lets us not rely on query parameters, which are limited in various ways. This PR updates the client accordingly. 

https://docs.scarf.sh/packages/#passing-variables-in-request-bodies