### PR TITLE
Normalize User-Agent delimiter

### DIFF
--- a/scarf/event_logger.py
+++ b/scarf/event_logger.py
@@ -58,7 +58,7 @@ class ScarfEventLogger:
                 f"{_sys.version_info.major}.{_sys.version_info.minor}.{_sys.version_info.micro}"
             )
 
-            extra = f" (platform={platform_name}; arch={arch}, python={pyver})"
+            extra = f" (platform={platform_name}; arch={arch}; python={pyver})"
         except Exception:
             # In case of any unexpected failure retrieving platform info,
             # fall back to just the base user agent string.

--- a/tests/test_event_logger.py
+++ b/tests/test_event_logger.py
@@ -384,10 +384,10 @@ class TestScarfEventLogger(unittest.TestCase):
         logger = ScarfEventLogger(endpoint_url=self.DEFAULT_ENDPOINT)
         ua = logger.session.headers['User-Agent']
         self.assertTrue(ua.startswith(f'scarf-py/{version}'))
-        # Expect appended details like: (platform=...; arch=..., python=...)
+        # Expect appended details like: (platform=...; arch=...; python=...)
         pattern = (
             r"^scarf-py/" + re.escape(version) +
-            r" \(platform=[^;]+; arch=[^,]+, python=\d+\.\d+\.\d+\)$"
+            r" \(platform=[^;]+; arch=[^;]+; python=\d+\.\d+\.\d+\)$"
         )
         self.assertRegex(ua, pattern)
 


### PR DESCRIPTION
Fixes #5 by standardizing the extended User-Agent properties to use semicolons throughout: (platform=...; arch=...; python=...).

Also updates the corresponding regex in tests/test_event_logger.py.
